### PR TITLE
Fixes release notes building

### DIFF
--- a/.changes/unreleased/Internal-20250913-172449.yaml
+++ b/.changes/unreleased/Internal-20250913-172449.yaml
@@ -1,0 +1,3 @@
+kind: Internal
+body: Fix release notes gathering in CI
+time: 2025-09-13T17:24:49.208661+02:00

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,10 +76,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Get release notes
-        id: notes
+      - name: Build release notes
         run: |
-          echo "contents=$(cat .changes/${{ needs.setup.outputs.version-tag }}.md)" >> "$GITHUB_OUTPUT"
+          cat .changes/${{ needs.setup.outputs.version-tag }}.md > combined_notes.md
+          echo '' >> combined_notes.md
+          echo 'Container image:' >> combined_notes.md
+          echo '- `ghcr.io/${{ github.repository }}:${{ needs.setup.outputs.version-tag }}`' >> combined_notes.md
+          echo '- `ghcr.io/${{ github.repository }}:latest`' >> combined_notes.md
 
       - name: Create git tag
         run: |
@@ -93,11 +96,6 @@ jobs:
         with:
           tag_name: ${{ needs.setup.outputs.version-tag }}
           name: ${{ needs.setup.outputs.version-tag }}
-          body: |
-            ${{ steps.notes.outputs.contents }}
-
-            Container image:
-            - `ghcr.io/${{ github.repository }}:${{ needs.setup.outputs.version-tag }}`
-            - `ghcr.io/${{ github.repository }}:latest`
+          body_path: combined_notes.md
           draft: false
           prerelease: false


### PR DESCRIPTION
cat'ing the contents of Markdown does not seems to work with GitHub Actions, so use the old school cat > into a file to combine both notes.